### PR TITLE
Cleanup on unmount()

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-expo-image-cache",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "React Native Image Cache and Progressive Loading based on Expo",
   "main": "dist/src/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -46,7 +46,9 @@
     "babel-cli": "^6.26.0",
     "babel-preset-react-native": "^4.0.0",
     "crypto-js": "^3.1.9-1",
-    "lodash": "^4.17.4"
+    "lodash": "^4.17.4",
+    "mobx": "^3.4.1",
+    "mobx-react": "^4.3.5"
   },
   "peerDependencies": {
     "expo": ">=24.0.0",

--- a/src/Image.js
+++ b/src/Image.js
@@ -4,6 +4,8 @@ import * as _ from "lodash";
 import * as React from "react";
 import {Image as RNImage, Animated, StyleSheet, View, Platform} from "react-native";
 import {BlurView} from "expo";
+import {observable, action}  from "mobx";
+import {observer} from "mobx-react/native";
 import {type StyleObj} from "react-native/Libraries/StyleSheet/StyleSheetTypes";
 
 import CacheManager from "./CacheManager";
@@ -14,14 +16,18 @@ type ImageProps = {
     uri: string
 };
 
-type ImageState = {
-    uri: string,
-    intensity: Animated.Value
-};
-
-export default class Image extends React.Component<ImageProps, ImageState> {
+@observer
+export default class Image extends React.Component<ImageProps> {
 
     style: StyleObj;
+
+    @observable intensity = new Animated.Value(100);
+    @observable uri: string;
+
+    @autobind @action
+    setURI(uri: string) {
+        this.uri = uri;
+    }
 
     load(props: ImageProps) {
         const {uri, style} = props;
@@ -29,12 +35,10 @@ export default class Image extends React.Component<ImageProps, ImageState> {
             StyleSheet.absoluteFill,
             _.pickBy(StyleSheet.flatten(style), (value, key) => propsToCopy.indexOf(key) !== -1)
         ];
-        CacheManager.cache(uri, newURI => this.setState({ uri: newURI }));
+        CacheManager.cache(uri, this.setURI);
     }
 
     componentWillMount() {
-        const intensity = new Animated.Value(100);
-        this.setState({ intensity });
         this.load(this.props);
     }
 
@@ -45,16 +49,15 @@ export default class Image extends React.Component<ImageProps, ImageState> {
     @autobind
     onLoadEnd() {
         const {preview} = this.props;
-        const {intensity} = this.state;
         if (preview) {
-            Animated.timing(intensity, { duration: 300, toValue: 0, useNativeDriver: true }).start();
+            Animated.timing(this.intensity, { duration: 300, toValue: 0, useNativeDriver: true }).start();
         }
     }
 
     render(): React.Node {
         const {style: computedStyle} = this;
         const {preview, style} = this.props;
-        const {uri, intensity} = this.state;
+        const {uri, intensity} = this;
         const hasPreview = !!preview;
         const opacity = intensity.interpolate({
             inputRange: [0, 100],

--- a/src/Image.js
+++ b/src/Image.js
@@ -4,7 +4,7 @@ import * as _ from "lodash";
 import * as React from "react";
 import {Image as RNImage, Animated, StyleSheet, View, Platform} from "react-native";
 import {BlurView} from "expo";
-import {observable, action}  from "mobx";
+import {observable, action} from "mobx";
 import {observer} from "mobx-react/native";
 import {type StyleObj} from "react-native/Libraries/StyleSheet/StyleSheetTypes";
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1388,8 +1388,8 @@ crc@3.3.0:
   resolved "https://registry.yarnpkg.com/crc/-/crc-3.3.0.tgz#fa622e1bc388bf257309082d6b65200ce67090ba"
 
 create-react-class@^15.5.2:
-  version "15.6.2"
-  resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.6.2.tgz#cf1ed15f12aad7f14ef5f2dfe05e6c42f91ef02a"
+  version "15.6.3"
+  resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.6.3.tgz#2d73237fb3f970ae6ebe011a9e66f46dbca80036"
   dependencies:
     fbjs "^0.8.9"
     loose-envify "^1.3.1"
@@ -3126,6 +3126,16 @@ minimist@~0.0.1:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
     minimist "0.0.8"
+
+mobx-react@^4.3.5:
+  version "4.3.5"
+  resolved "https://registry.yarnpkg.com/mobx-react/-/mobx-react-4.3.5.tgz#76853f2f2ef4a6f960c374bcd9f01e875929c04c"
+  dependencies:
+    hoist-non-react-statics "^2.3.1"
+
+mobx@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/mobx/-/mobx-3.4.1.tgz#37abe5ee882d401828d9f26c6c1a2f47614bbbef"
 
 morgan@~1.6.1:
   version "1.6.1"


### PR DESCRIPTION
I switched from manual state management to mobx, un order to avoid side effects when the component is unmounted. Ideally, this could be done without mobx by unsubscribing in `componentWillUnmount()` but I wasn't able to do it i a reliable manner. As an emergency fix, the package will use mobx for now. 