### PR TITLE
Support require('path') usage

### DIFF
--- a/src/Image.js
+++ b/src/Image.js
@@ -91,8 +91,8 @@ export default class Image extends React.Component<ImageProps, ImageState> {
                     (hasDefaultSource && !hasPreview && !hasURI) && (
                         <RNImage
                             source={imageSourceHandling(defaultSource)}
-                            resizeMode="cover"
                             style={computedStyle}
+                            {...otherProps}
                         />
                     )
                 }

--- a/src/Image.js
+++ b/src/Image.js
@@ -64,8 +64,9 @@ export default class Image extends React.Component<ImageProps, ImageState> {
 
     render(): React.Node {
         const {style: computedStyle} = this;
-        const {preview, style} = this.props;
+        const {requireHook, preview, style} = this.props;
         const {uri, intensity} = this.state;
+        const hasRequireHook = !!requireHook
         const hasPreview = !!preview;
         const opacity = intensity.interpolate({
             inputRange: [0, 100],
@@ -73,6 +74,15 @@ export default class Image extends React.Component<ImageProps, ImageState> {
         });
         return (
             <View {...{style}}>
+                {
+                    hasRequireHook && preview == null && uri == null (
+                        <RNImage
+                            source={hasRequireHook}
+                            resizeMode="cover"
+                            style={computedStyle}
+                        />
+                    )
+                }
                 {
                     hasPreview && (
                         <RNImage

--- a/src/Image.js
+++ b/src/Image.js
@@ -4,13 +4,14 @@ import * as React from "react";
 import {Image as RNImage, Animated, StyleSheet, View, Platform} from "react-native";
 import {BlurView} from "expo";
 import {type StyleObj} from "react-native/Libraries/StyleSheet/StyleSheetTypes";
+import typeof {ImageSourcePropType} from "react-native/Libraries/Image/ImageSourcePropType";
 
 import CacheManager from "./CacheManager";
 
 type ImageProps = {
     style?: StyleObj,
-    defaultSource?: string | ImageSourcePropTypes | number,
-    preview?: string | ImageSourcePropTypes | number,
+    defaultSource?: string | ImageSourcePropType,
+    preview?: string | ImageSourcePropType,
     uri: string
 };
 
@@ -19,7 +20,7 @@ type ImageState = {
     intensity: Animated.Value
 };
 
-function imageSourceHandling(source: string | ImageSourcePropTypes | number): ImageSourcePropTypes | number {
+function imageSourceHandling(source: string | ImageSourcePropType): ImageSourcePropType {
     if (Object.prototype.toString.call(source) === "[object String]") {
         return { uri: source };
     }

--- a/src/Image.js
+++ b/src/Image.js
@@ -28,6 +28,7 @@ export default class Image extends React.Component<ImageProps, ImageState> {
         const {uri, style} = props;
         this.style = [
             StyleSheet.absoluteFill,
+            { width: "100%", height: "100%" },
             _.pickBy(StyleSheet.flatten(style), (value, key) => propsToCopy.indexOf(key) !== -1)
         ];
         uri && CacheManager.cache(uri, this.setURI);

--- a/src/Image.js
+++ b/src/Image.js
@@ -65,9 +65,9 @@ export default class Image extends React.Component<ImageProps, ImageState> {
 
     render(): React.Node {
         const {style: computedStyle} = this;
-        const {requireHook, preview, style} = this.props;
+        const {defaultSource, preview, style} = this.props;
         const {uri, intensity} = this.state;
-        const hasRequireHook = !!requireHook
+        const hasDefaultSource = !!defaultSource
         const hasPreview = !!preview;
         const opacity = intensity.interpolate({
             inputRange: [0, 100],
@@ -76,9 +76,9 @@ export default class Image extends React.Component<ImageProps, ImageState> {
         return (
             <View {...{style}}>
                 {
-                    (hasRequireHook && preview === undefined && uri === undefined) && (
+                    (hasDefaultSource && preview === undefined && uri === undefined) && (
                         <RNImage
-                            source={requireHook}
+                            source={defaultSource}
                             resizeMode="cover"
                             style={computedStyle}
                         />

--- a/src/Image.js
+++ b/src/Image.js
@@ -76,7 +76,7 @@ export default class Image extends React.Component<ImageProps, ImageState> {
         return (
             <View {...{style}}>
                 {
-                    (hasDefaultSource && preview === undefined && uri === undefined) && (
+                    (hasDefaultSource && preview == undefined && uri == undefined) && (
                         <RNImage
                             source={defaultSource}
                             resizeMode="cover"

--- a/src/Image.js
+++ b/src/Image.js
@@ -30,7 +30,7 @@ export default class Image extends React.Component<ImageProps, ImageState> {
             StyleSheet.absoluteFill,
             _.pickBy(StyleSheet.flatten(style), (value, key) => propsToCopy.indexOf(key) !== -1)
         ];
-        CacheManager.cache(uri, this.setURI);
+        uri && CacheManager.cache(uri, this.setURI);
     }
 
     componentWillMount() {
@@ -75,9 +75,9 @@ export default class Image extends React.Component<ImageProps, ImageState> {
         return (
             <View {...{style}}>
                 {
-                    hasRequireHook && preview == null && uri == null (
+                    (hasRequireHook && preview === undefined && uri === undefined) && (
                         <RNImage
-                            source={hasRequireHook}
+                            source={requireHook}
                             resizeMode="cover"
                             style={computedStyle}
                         />


### PR DESCRIPTION
In case the same Image component need to display local image by `require` originally, and setting `preview` + `uri` afterwards