### PR TITLE
Use a smaller borderRadius according to borderWidth

### DIFF
--- a/src/Image.js
+++ b/src/Image.js
@@ -28,7 +28,12 @@ export default class Image extends React.Component<ImageProps, ImageState> {
         const {uri, style} = props;
         this.style = [
             StyleSheet.absoluteFill,
-            _.pickBy(StyleSheet.flatten(style), (value, key) => propsToCopy.indexOf(key) !== -1)
+            _.transform(
+                _.pickBy(StyleSheet.flatten(style), (value, key) => propsToCopy.indexOf(key) !== -1),
+                (result, value, key) => {
+                    result[key] = value - style.borderWidth
+                }
+            )
         ];
         CacheManager.cache(uri, this.setURI);
     }


### PR DESCRIPTION
The children components should have a smaller radius when `borderWidth` exists