### PR TITLE
Add blur effect for Android also

### DIFF
--- a/src/Image.js
+++ b/src/Image.js
@@ -81,6 +81,7 @@ export default class Image extends React.Component<ImageProps, ImageState> {
                             source={{ uri: preview }}
                             resizeMode="cover"
                             style={computedStyle}
+                            blurRadius={Platform.OS === "android" ? 1 : 0}
                         />
                     )
                 }


### PR DESCRIPTION
Using Facebook's Fresco IterativeBoxBlurPostProcessor to blur the preview image, CPU intensive but acceptable for small base64 image, doesn't have the same remove blur animation as iOS but it looks much better now