### PR TITLE
Compatibility with direct npm/yarn installation from Github forks/branches

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "flow": "flow check --show-all-errors | flow-result-checker",
     "lint": "eslint App.js src/",
     "test": "yarn lint && yarn flow",
-    "prepare": "install-self-peers -- --ignore-scripts"
+    "prepare": "npm run compile && install-self-peers -- --ignore-scripts"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Compile the source code for npm install from <git-host>, so for developers who like to test their own fork can use npm install directly without adding the `dist/src` folder manually