### PR TITLE
Do not cache image results with a non-200 status result

### DIFF
--- a/src/CacheManager.js
+++ b/src/CacheManager.js
@@ -20,7 +20,10 @@ export class CacheEntry {
         if (exists) {
             return path;
         }
-        await FileSystem.downloadAsync(uri, tmpPath);
+        const { status } = await FileSystem.downloadAsync(uri, tmpPath);
+        if (status !== 200) {
+            return undefined;
+        }
         await FileSystem.moveAsync({ from: tmpPath, to: path });
         return path;
     }


### PR DESCRIPTION
I've been experiencing an issue in which our CDN returns a non-200 error response for certain image assets. The response body is placed into the image cache, and when it's rendered using an `<Image/>`, nothing is displayed. This PR will return `undefined` when there is a non-200 response from an image request.