### PR TITLE
fix: put expo-blur as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,12 +37,12 @@
     "@types/react-native": "^0.57.63",
     "eslint": "^5.16.0",
     "eslint-config-react-native-wcandillon": "^1.2.2",
-    "expo-blur": "^5.0.1",
     "expo-file-system": "^5.0.1"
   },
   "dependencies": {
     "crypto-js": "^3.1.9-1",
-    "lodash": "^4.17.4"
+    "lodash": "^4.17.4",
+    "expo-blur": "^6.0.0"
   },
   "peerDependencies": {
     "expo-blur": "*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1137,9 +1137,10 @@ execa@^0.6.1:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
-expo-blur@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/expo-blur/-/expo-blur-5.0.1.tgz#39edbb391965ec3b426ded6b869618d8294dd56c"
+expo-blur@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/expo-blur/-/expo-blur-6.0.0.tgz#c63e7c464e1a8137dae8a71f893426a538eb9ed9"
+  integrity sha512-UqMaE2G2DfoeEJCYFfFLXq9nBeD0m3G1IISpxmdLXHDvzQuFl0kzNAZXX81a9sByWTV85KsxxnxoLImbfxV33A==
   dependencies:
     prop-types "^15.6.0"
 


### PR DESCRIPTION
### Motivation
With the release of `expo` sdk 34 the package `expo-blur` is no longer bundled in the `expo` package, so it should be listed as a dependency.