### PR TITLE
fix: types do not live in `src` folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "React Native Image Cache and Progressive Loading based on Expo",
   "main": "dist/module/index.js",
   "react-native": "dist/module/index.js",
-  "types": "dist/typescript/src/index.d.ts",
+  "types": "dist/typescript/index.d.ts",
   "files": [
     "src",
     "dist"


### PR DESCRIPTION
typescript types couldn't be loaded because they were referred to incorrectly.