### PR TITLE
Optional fallback option

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   },
   "dependencies": {
     "crypto-js": "^3.1.9-1",
+    "expo-asset": "^6.0.0",
     "lodash": "^4.17.4"
   },
   "peerDependencies": {

--- a/src/Image.tsx
+++ b/src/Image.tsx
@@ -13,7 +13,7 @@ import {
   StyleProp
 } from "react-native";
 import { BlurView } from "expo-blur";
-import { Asset } from 'expo-asset';
+import { Asset } from "expo-asset";
 
 import CacheManager, { DownloadOptions } from "./CacheManager";
 

--- a/src/Image.tsx
+++ b/src/Image.tsx
@@ -13,6 +13,7 @@ import {
   StyleProp
 } from "react-native";
 import { BlurView } from "expo-blur";
+import { Asset } from 'expo-asset';
 
 import CacheManager, { DownloadOptions } from "./CacheManager";
 
@@ -24,6 +25,7 @@ interface ImageProps {
   uri: string;
   transitionDuration?: number;
   tint?: "dark" | "light";
+  fallback?: number;
 }
 
 interface ImageState {
@@ -66,10 +68,13 @@ export default class Image extends React.Component<ImageProps, ImageState> {
     this.mounted = false;
   }
 
-  async load({ uri, options = {} }: ImageProps): Promise<void> {
+  async load({ uri, options = {}, fallback }: ImageProps): Promise<void> {
     if (uri) {
-      const path = await CacheManager.get(uri, options).getPath();
+      let path = await CacheManager.get(uri, options).getPath();
       if (this.mounted) {
+        if (!path && fallback && Number.isInteger(fallback)) {
+          path = Asset.fromModule(fallback).uri;
+        }
         this.setState({ uri: path });
       }
     }


### PR DESCRIPTION
Added optional fallback option in case CacheManager fails to download the main image with error response code different from 200. Fallback should be provided as a local asset module.

@wcandillon Hi there. Thanks for the awesome plugin! Being using it a lot. However, for the current project, I faced an issue: when the image URL is broken or there is a network issue, blurry preview keeps hanging forever. I thought would be good to be able to fall back to some default thumbnail in this case.
Let me know what you think. Thanks

Example of usage:

const fallback = require('...');
...
<Image {...{ preview, uri }} fallback={fallback} />
