### PR TITLE
Image caching improvements

### DIFF
--- a/src/Image.tsx
+++ b/src/Image.tsx
@@ -22,6 +22,7 @@ interface ImageProps {
   preview?: ImageSourcePropType;
   options?: DownloadOptions;
   uri: string;
+  cacheKey?: string;
   transitionDuration?: number;
   tint?: "dark" | "light";
 }
@@ -66,9 +67,9 @@ export default class Image extends React.Component<ImageProps, ImageState> {
     this.mounted = false;
   }
 
-  async load({ uri, options = {} }: ImageProps): Promise<void> {
+  async load({ uri, options = {}, cacheKey }: ImageProps): Promise<void> {
     if (uri) {
-      const path = await CacheManager.get(uri, options).getPath();
+      const path = await CacheManager.get(uri, options, cacheKey || uri).getPath();
       if (this.mounted) {
         this.setState({ uri: path });
       }


### PR DESCRIPTION
Some improvements that I suggested in #126 & #127 -

The first commit adds an optional cache key property to `Image` to use instead of the `uri` as the cache key.

The second commit avoids repeat downloads if multiple `Image` components reference the same `uri`.