### PR TITLE
chore: import individual methods from lodash

### DIFF
--- a/src/CacheManager.ts
+++ b/src/CacheManager.ts
@@ -1,5 +1,4 @@
-// @flow
-import * as _ from "lodash";
+import uniqueId from "lodash/uniqueId";
 import * as FileSystem from "expo-file-system";
 import SHA1 from "crypto-js/sha1";
 
@@ -64,7 +63,7 @@ const getCacheEntry = async (uri: string): Promise<{ exists: boolean; path: stri
   const filename = uri.substring(uri.lastIndexOf("/"), uri.indexOf("?") === -1 ? uri.length : uri.indexOf("?"));
   const ext = filename.indexOf(".") === -1 ? ".jpg" : filename.substring(filename.lastIndexOf("."));
   const path = `${BASE_DIR}${SHA1(uri)}${ext}`;
-  const tmpPath = `${BASE_DIR}${SHA1(uri)}-${_.uniqueId()}${ext}`;
+  const tmpPath = `${BASE_DIR}${SHA1(uri)}-${uniqueId()}${ext}`;
   // TODO: maybe we don't have to do this every time
   try {
     await FileSystem.makeDirectoryAsync(BASE_DIR);

--- a/src/Image.tsx
+++ b/src/Image.tsx
@@ -1,5 +1,5 @@
-// @flow
-import * as _ from "lodash";
+import pickBy from "lodash/pickBy";
+import transform from "lodash/transform";
 import * as React from "react";
 import {
   Image as RNImage,
@@ -96,7 +96,7 @@ export default class Image extends React.Component<ImageProps, ImageState> {
     const flattenedStyle = StyleSheet.flatten(style);
     const computedStyle: StyleProp<ImageStyle> = [
       StyleSheet.absoluteFill,
-      _.transform(_.pickBy(flattenedStyle, (_val, key) => propsToCopy.indexOf(key) !== -1), (result, value: any, key) =>
+      transform(pickBy(flattenedStyle, (_val, key) => propsToCopy.indexOf(key) !== -1), (result, value: any, key) =>
         Object.assign(result, { [key]: value - (flattenedStyle.borderWidth || 0) })
       )
     ];


### PR DESCRIPTION
I've noticed that this package was importing the whole lodash package for few methods.

I've modified it to have each methods imported individually to take less space.

I've also removed the `//@flow` notation as this package is no not using flow.

| comparison | |
| --- | --- |
| before | <img src="https://user-images.githubusercontent.com/6936373/71505914-5ef36f80-28c2-11ea-9175-70e35e754d2a.png"  /> | 
| after | <img src="https://user-images.githubusercontent.com/6936373/71505912-5ef36f80-28c2-11ea-89d9-3ea46ed3ebb6.png"  /> |



